### PR TITLE
rely on udev to manage symlinks, closes #2

### DIFF
--- a/999-aws-ebs-nvme.rules
+++ b/999-aws-ebs-nvme.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="block", KERNEL=="nvme[0-9]*n[0-9]*", ATTRS{model}=="Amazon Elastic Block Store", PROGRAM+="/usr/local/sbin/nvme-mapping.sh /dev/%k" SYMLINK+="%c"
+SUBSYSTEM=="block", KERNEL=="nvme[0-9]*n[0-9]*", ATTRS{model}=="Amazon Elastic Block Store", PROGRAM+="/usr/local/sbin/ebs-nvme-mapping.sh /dev/%k" SYMLINK+="%c"

--- a/999-aws-ebs-nvme.rules
+++ b/999-aws-ebs-nvme.rules
@@ -1,1 +1,1 @@
-ACTION=="add", SUBSYSTEM=="block", KERNEL=="nvme[1-26]n1", ATTRS{model}=="Amazon Elastic Block Store              ", RUN+="/usr/local/bin/ebs-nvme-mapping"
+SUBSYSTEM=="block", KERNEL=="nvme[0-9]*n[0-9]*", ATTRS{model}=="Amazon Elastic Block Store", PROGRAM+="/usr/local/sbin/nvme-mapping.sh /dev/%k" SYMLINK+="%c"

--- a/ebs-nvme-mapping.sh
+++ b/ebs-nvme-mapping.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
+# Inspired by https://github.com/oogali/ebs-automatic-nvme-mapping
+# Thanks Oogali!
+# Tested on Ubuntu 16.04
+# To be used with the below udev rule (/etc/udev/rules.d/999-aws-ebs-nvme.rules)
+# SUBSYSTEM=="block", KERNEL=="nvme[0-9]*n[0-9]*", ATTRS{model}=="Amazon Elastic Block Store", PROGRAM+="/usr/local/sbin/ebs-nvme-mapping.sh /dev/%k" SYMLINK+="%c"
 
-PATH="${PATH}:/usr/sbin"
-
-for blkdev in $( nvme list | awk '/^\/dev/ { print $1 }' ) ; do
-  mapping=$(nvme id-ctrl --raw-binary "${blkdev}" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g')
-  if [[ "${mapping}" == /dev/* ]]; then
-    ( test -b "${blkdev}" && test -L "${mapping}" ) || ln -s "${blkdev}" "${mapping}"
-  fi
-done
+if [[ -x /usr/sbin/nvme ]] && [[ -b ${1} ]]; then
+  # capture 32 bytes at an offset of 3072 bytes from the raw-binary data
+  # not all block devices are extracted with /dev/ prefix
+  # use `xvd` prefix instead of `sd`
+  # remove all trailing space
+  nvme_link=$( \
+    /usr/sbin/nvme id-ctrl --raw-binary "${1}" | \
+    /usr/bin/cut -c3073-3104 | \
+    /bin/sed 's/^\/dev\///g'| \
+    /bin/sed 's/^sd/xvd/'| \
+    /usr/bin/tr -d '[:space:]' \
+  );
+  echo $nvme_link;
+fi


### PR DESCRIPTION
 * uses `xvd` notation to match Ubuntu default for Xen virtual devices
 * uses [:space:] character set to delete all whitespace
 * move script to `/usr/local/sbin` as this is a system script