### PR TITLE
use --output binary instead of --raw-binary

### DIFF
--- a/ebs-nvme-mapping.sh
+++ b/ebs-nvme-mapping.sh
@@ -16,7 +16,7 @@ fi
 # use `xvd` prefix instead of `sd`
 # remove all trailing space
 nvme_link=$( \
-  nvme id-ctrl --raw-binary "${1}" | \
+  nvme id-ctrl --output binary "${1}" | \
   cut -c3073-3104 | \
   sed 's/^\/dev\///g'| \
   tr -d '[:space:]' \


### PR DESCRIPTION
on CentOS 7.6 using `nvme version 1.8.1` the following happens when using `--raw-binary`

```
nvme id-ctrl --raw-binary /dev/nvme0n1 | cut -c3073-3104
binary output
sda1
```

but with `--output binary` the `binary output` doesn't show up

```
nvme id-ctrl -o binary /dev/nvme0n1 | cut -c3073-3104
sda1
```

I know it doesn't return `/dev/` - That's a different problem which I don't know how to solve yet