### PR TITLE
Checking for 2 mapping names

### DIFF
--- a/ebs-nvme-mapping.sh
+++ b/ebs-nvme-mapping.sh
@@ -2,9 +2,11 @@
 
 PATH="${PATH}:/usr/sbin"
 
-for blkdev in $( nvme list | awk '/^\/dev/ { print $1 }' ) ; do
+for blkdev in $( nvme list | grep 'Amazon Elastic Block Store              ' | awk '/^\/dev/ { print $1 }' ) ; do
   mapping=$(nvme id-ctrl --raw-binary "${blkdev}" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g')
   if [[ "${mapping}" == /dev/* ]]; then
     ( test -b "${blkdev}" && test -L "${mapping}" ) || ln -s "${blkdev}" "${mapping}"
+  elif [[ "/dev/${mapping}" == /dev/* ]]; then
+    ( test -b "${blkdev}" && test -L "/dev/${mapping}" ) || ln -s "${blkdev}" "/dev/${mapping}"
   fi
 done


### PR DESCRIPTION
### Limiting `nvme list` results to EBS only

Since `nvme list` could also output Instance Storage, I think it is a good idea to limit your results to only the volumes you want to support

```
root@ip-10-XXX-XXX-XXX:~# nvme list
Node             SN                   Model                                    Namespace Usage                      Format           FW Rev
---------------- -------------------- ---------------------------------------- --------- -------------------------- ---------------- --------
/dev/nvme0n1     vol00000000000000000 Amazon Elastic Block Store               1           0.00   B /  53.69  GB    512   B +  0 B   1.0
/dev/nvme2n1     vol11111111111111111 Amazon Elastic Block Store               1           0.00   B / 214.75  GB    512   B +  0 B   1.0
/dev/nvme1n1     AWS22222222222222222 Amazon EC2 NVMe Instance Storage         1          75.00  GB /  75.00  GB    512   B +  0 B   0
```

### Checking for both mappings scenarios (/dev/\<something> and \<something>)

```
root@ip-10-XXX-XXX-XXX:~# bash -x ebs-nvme-mapping
++ awk '/^\/dev/ { print $1 }'
++ grep 'Amazon Elastic Block Store              '
++ nvme list
+ for blkdev in '$( nvme list | grep '\''Amazon Elastic Block Store              '\'' | awk '\''/^\/dev/ { print $1 }'\'' )'
++ sed 's/ $//g'
++ tr -s ' '
++ cut -c3073-3104
++ nvme id-ctrl --raw-binary /dev/nvme0n1
+ mapping=sda1
+ [[ sda1 == /dev/* ]]
+ [[ /dev/sda1 == /dev/* ]]
+ test -b /dev/nvme0n1
+ test -L /dev/sda1
+ ln -s /dev/nvme0n1 /dev/sda1
+ for blkdev in '$( nvme list | grep '\''Amazon Elastic Block Store              '\'' | awk '\''/^\/dev/ { print $1 }'\'' )'
++ nvme id-ctrl --raw-binary /dev/nvme2n1
++ sed 's/ $//g'
++ tr -s ' '
++ cut -c3073-3104
+ mapping=/dev/xvdb
+ [[ /dev/xvdb == /dev/* ]]
+ test -b /dev/nvme2n1
+ test -L /dev/xvdb
+ ln -s /dev/nvme2n1 /dev/xvdb
```