### PR TITLE
fix udev pattern to match all the nvme devices

### DIFF
--- a/999-aws-ebs-nvme.rules
+++ b/999-aws-ebs-nvme.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="block", KERNEL=="nvme[0-26]n1", ATTRS{model}=="Amazon Elastic Block Store", PROGRAM+="/usr/local/sbin/ebs-nvme-mapping.sh /dev/%k" SYMLINK+="%c"
+SUBSYSTEM=="block", KERNEL=="nvme[0-9]*n1", ATTRS{model}=="Amazon Elastic Block Store", PROGRAM+="/usr/local/sbin/ebs-nvme-mapping.sh /dev/%k" SYMLINK+="%c"


### PR DESCRIPTION
the pattern before said `nvme[0-26]n1` which would only match

* nvme0n1
* nvme1n1
* nvme2n1
* nvme6n1

the range is not zero to twenty-six, it is 0 to 2 and also 6

I think that `[0-9][0-9]*` is better. because it'll get any one or two digit devices