### PR TITLE
Fix nvme binary check

### DIFF
--- a/ebs-nvme-mapping.sh
+++ b/ebs-nvme-mapping.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # To be used with the udev rule: /etc/udev/rules.d/999-aws-ebs-nvme.rules
 
-if [[ -z nvme ]]; then
+if [[ -z $(command -v nvme) ]]; then
   echo "ERROR: NVME tools not installed." >> /dev/stderr
   exit 1
 fi


### PR DESCRIPTION
The check `[[ -z nvme ]]` can't ever fail, since it's checking the
string and not the presence of a binary.

Wrap that in $(command -v) to check for the binary.