### PR TITLE
fix patterns in udev rule to work for multiple digits again

### DIFF
--- a/999-aws-ebs-nvme.rules
+++ b/999-aws-ebs-nvme.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="block", KERNEL=="nvme[0-9]*n1", ATTRS{model}=="Amazon Elastic Block Store", PROGRAM+="/usr/local/sbin/ebs-nvme-mapping.sh /dev/%k" SYMLINK+="%c"
+SUBSYSTEM=="block", KERNEL=="nvme[0-9]*n[0-9]*", ATTRS{model}=="Amazon Elastic Block Store", PROGRAM+="/usr/local/sbin/ebs-nvme-mapping.sh /dev/%k" SYMLINK+="%c"

--- a/ebs-nvme-mapping.sh
+++ b/ebs-nvme-mapping.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # To be used with the udev rule: /etc/udev/rules.d/999-aws-ebs-nvme.rules
 
-if [[ -z nvme ]]; then
+if [[ -z $(command -v nvme) ]]; then
   echo "ERROR: NVME tools not installed." >> /dev/stderr
   exit 1
 fi

--- a/ebs-nvme-mapping.sh
+++ b/ebs-nvme-mapping.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # To be used with the udev rule: /etc/udev/rules.d/999-aws-ebs-nvme.rules
 
-if [[ -z $(command -v nvme) ]]; then
+if [[ -z $(command -v /usr/sbin/nvme) ]]; then
   echo "ERROR: NVME tools not installed." >> /dev/stderr
   exit 1
 fi
@@ -16,9 +16,9 @@ fi
 # use `xvd` prefix instead of `sd`
 # remove all trailing space
 nvme_link=$( \
-  nvme id-ctrl --output binary "${1}" | \
-  cut -c3073-3104 | \
-  sed 's/^\/dev\///g'| \
-  tr -d '[:space:]' \
+  /usr/sbin/nvme id-ctrl --output binary "${1}" | \
+  /usr/bin/cut -c3073-3104 | \
+  /bin/sed 's/^\/dev\///g'| \
+  /usr/bin/tr -d '[:space:]' \
 );
 echo $nvme_link;


### PR DESCRIPTION
also fix paths in `ebs-nvme-mapping.sh`

this had previously been fixed in #3 but it was changed before it was merged.

then I tried to fix it again in #8 but missed some of the digits

rebased on top of @pforman-zymergen's PR #13 because I want that binary check but udev needs the full paths.